### PR TITLE
Changed [] to array()

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -52,7 +52,7 @@ class Api {
   }
 
   public static function request($url, $method = null, $params = null) {
-    $opts = [];
+    $opts = array();
     $curl = curl_init();
     $method = strtolower($method);
 


### PR DESCRIPTION
This change just an incompatible array declaration '[]' with 'array()' that is compatible with all PHP versions