### PR TITLE
Fix for Api.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ https://s3-eu-west-1.amazonaws.com/docs.online.satispay.com/index.html
 
 // Set client, use this format: Platform/x.x.x (not mandatory)
 \SatispayOnline\Api::setClient('WordPress/4.8 WooCommerce/3.1.1');
+
+// Get client
+\SatispayOnline\Api::getClient();
 ```
 
 ### Examples

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace SatispayOnline;
 
-define('SDKVERSION', '1.3.0');
+define('SDKVERSION', '1.3.1');
 
 class Api {
   public static $securityBearer;
@@ -42,6 +42,13 @@ class Api {
 
   public static function setClient($client) {
     self::$client = $client;
+  }
+
+  public static function getClient() {
+    return join(' ', array(
+      self::$client,
+      'PHP/'.phpversion()
+    ))
   }
 
   public static function request($url, $method = null, $params = null) {

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace SatispayOnline;
 
-define('SDKVERSION', '1.3.1');
+define('SDKVERSION', '1.3.2');
 
 class Api {
   public static $securityBearer;
@@ -52,7 +52,7 @@ class Api {
   }
 
   public static function request($url, $method = null, $params = null) {
-    $opts = [];
+    $opts = array();
     $curl = curl_init();
     $method = strtolower($method);
 

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -48,7 +48,7 @@ class Api {
     return join(' ', array(
       self::$client,
       'PHP/'.phpversion()
-    ))
+    ));
   }
 
   public static function request($url, $method = null, $params = null) {


### PR DESCRIPTION
Fixing a missed semicolon.

`PHP Parse error:  syntax error, unexpected '}' in satispay/online-api-php-sdk/lib/Api.php on line 52,`